### PR TITLE
Fix for 'detect_type' failing when Dir.pwd returns a path without trailing slash

### DIFF
--- a/lib/rspec/terraspace/project.rb
+++ b/lib/rspec/terraspace/project.rb
@@ -133,7 +133,7 @@ module RSpec::Terraspace
     # Returns: modules or stacks
     def detected_type
       dir = Dir.pwd
-      md = dir.match(%r{app/(stacks|modules)/(.*)?/})
+      md = dir.match(%r{app/(stacks|modules)/(.*)?/?})
       md[1]
     end
 


### PR DESCRIPTION
Fixes issue #9

https://github.com/boltops-tools/rspec-terraspace/issues/9